### PR TITLE
fix(fd2): Co-author only in commit message

### DIFF
--- a/test_case_5/testfile.txt
+++ b/test_case_5/testfile.txt
@@ -1,0 +1,1 @@
+Change for: fix(fd2): Co-author only in commit message


### PR DESCRIPTION
Testing co-author in commit message only.