### PR TITLE
perf(lib): Co-author only in PR description

### DIFF
--- a/test_case_4/testfile.txt
+++ b/test_case_4/testfile.txt
@@ -1,0 +1,1 @@
+Change for: perf(lib): Co-author only in PR description


### PR DESCRIPTION
Testing co-author in PR description only.

Co-authored-by: Grant Braught <braught@dickinson.edu>